### PR TITLE
DAEMON-372: create shutdown event for shutdown process

### DIFF
--- a/src/native/windows/apps/prunsrv/prunsrv.c
+++ b/src/native/windows/apps/prunsrv/prunsrv.c
@@ -1016,6 +1016,8 @@ static DWORD WINAPI serviceStop(LPVOID lpParameter)
             apxLogWrite(APXLOG_MARK_ERROR "Failed creating process");
             return 1;
         }
+        /* Create shutdown event */
+        gShutdownEvent = CreateEvent(NULL, TRUE, FALSE, NULL);
         if (!apxProcessSetExecutableW(hWorker, SO_STOPIMAGE)) {
             apxLogWrite(APXLOG_MARK_ERROR "Failed setting process executable %S",
                         SO_STOPIMAGE);


### PR DESCRIPTION
On Windows, when using Java or exe modes, if the service process ends before the stop process, prunsrv starts clean up.
When the stop process finishes, the handles might be freed and all sorts of illegal access errors may happen.
The solution is to make the service execution to wait on the shutdown event.