### PR TITLE
DAEMON-243: Failure of Windows service when child process fails

### DIFF
--- a/src/native/windows/apps/prunsrv/prunsrv.c
+++ b/src/native/windows/apps/prunsrv/prunsrv.c
@@ -1421,6 +1421,7 @@ void WINAPI serviceMain(DWORD argc, LPTSTR *argv)
     _service_status.dwCheckPoint       = 0;
     _service_status.dwWaitHint         = 0;
     _service_status.dwServiceSpecificExitCode = 0;
+    DWORD vmExitCode;
 
     apxLogWrite(APXLOG_MARK_DEBUG "Inside ServiceMain...");
 
@@ -1574,7 +1575,6 @@ void WINAPI serviceMain(DWORD argc, LPTSTR *argv)
         }
     }
     reportServiceStatus(SERVICE_START_PENDING, NO_ERROR, 3000);
-    DWORD vmExitCode;
     if ((rc = serviceStart()) == 0) {
         /* Service is started */
         reportServiceStatus(SERVICE_RUNNING, NO_ERROR, 0);

--- a/src/native/windows/apps/prunsrv/prunsrv.c
+++ b/src/native/windows/apps/prunsrv/prunsrv.c
@@ -1413,6 +1413,8 @@ BOOL WINAPI console_handler(DWORD dwCtrlType)
 /* Main service execution loop */
 void WINAPI serviceMain(DWORD argc, LPTSTR *argv)
 {
+    DWORD vmExitCode = 0;
+    BOOL serviceFailed = FALSE;
     DWORD rc = 0;
     _service_status.dwServiceType      = SERVICE_WIN32_OWN_PROCESS;
     _service_status.dwCurrentState     = SERVICE_START_PENDING;
@@ -1421,7 +1423,6 @@ void WINAPI serviceMain(DWORD argc, LPTSTR *argv)
     _service_status.dwCheckPoint       = 0;
     _service_status.dwWaitHint         = 0;
     _service_status.dwServiceSpecificExitCode = 0;
-    DWORD vmExitCode;
 
     apxLogWrite(APXLOG_MARK_DEBUG "Inside ServiceMain...");
 
@@ -1590,9 +1591,7 @@ void WINAPI serviceMain(DWORD argc, LPTSTR *argv)
         apxLogWrite(APXLOG_MARK_ERROR "ServiceStart returned %d", rc);
         goto cleanup;
     }
-    BOOL serviceFailed;
     if (gShutdownEvent) {
-        serviceFailed = FALSE;
         /* Ensure that shutdown thread exits before us */
         apxLogWrite(APXLOG_MARK_DEBUG "Waiting for ShutdownEvent");
         reportServiceStatus(SERVICE_STOP_PENDING, NO_ERROR, ONE_MINUTE);


### PR DESCRIPTION
prunsrv should to not report about stopped status of Windows service when its child process (`StartMode` == `exe`) exits with non-zero exit code (i.e. fails) - this behavior is treated by Windows service control manager as a failure of Windows service and service recovery actions can be applied for this case.

This feature provides users of prunsrv ability to pass failure of application (as non-zero exit code of that application) to Windows service control manager and to use standard service recovery actions to handle such cases.

Current behavior of prunsrv is to report about stopped state with the same exit code  as child process returned. This behavior doesn't trigger service recovery actions without [`FailureActionsOnNonCrashFailures`](https://msdn.microsoft.com/ru-ru/library/windows/desktop/ms685937(v=vs.85).aspx) flag for the service and this flag is not configured by prunsrv when it installs new service.