### PR TITLE
DAEMON-399: apxStrUnQuoteInplaceA removes needed quotes

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -58,6 +58,9 @@
       <action issue="DAEMON-392" type="fix" dev="ggregory" due-to="Daniel Hofmann">
         Undefined behaviour in registry.c dwRegKey = dwRegKey++
       </action>
+      <action issue="DAEMON-399" type="fix" dev="spjoe" due-to="Camillo Dell'mour">
+        apxStrUnQuoteInplaceA removes needed quotes.
+      </action>
     </release>
     <release version="1.1.0" date="2017-11-15" description="Feature and bug fix release">
       <action issue="DAEMON-368" type="add" dev="ggregory">

--- a/src/native/windows/src/javajni.c
+++ b/src/native/windows/src/javajni.c
@@ -467,22 +467,18 @@ static DWORD __apxMultiSzToJvmOptions(APXHANDLE hPool,
     if (lpString)
         AplCopyMemory(p, lpString, l + 1);
     for (i = 0; i < n; i++) {
-        DWORD qr = apxStrUnQuoteInplaceA(p);
         (*lppArray)[i].optionString = p;
         while (*p)
             p++;
         p++;
-        p += qr;
     }
     if (lpString9)
         AplCopyMemory(p, lpString9, l9 + 1);
     for (i = n; i < (n + n9); i++) {
-        DWORD qr = apxStrUnQuoteInplaceA(p);
         (*lppArray)[i].optionString = p;
         while (*p)
             p++;
         p++;
-        p += qr;
     }
 
     return nTotal;


### PR DESCRIPTION
For some JVM options quotes are needed even if no space is within the option.