### PR TITLE
apsupport.m4: improve mips detect

### DIFF
--- a/src/native/unix/support/apsupport.m4
+++ b/src/native/unix/support/apsupport.m4
@@ -116,7 +116,12 @@ AC_DEFUN(AP_SUPPORTED_HOST,[
     LDCMD="/opt/C/bin/cc"
     HOST_CPU=osd
     ;;
-  mips | mipsn32 | mips64)
+  mips*el)
+    CFLAGS="$CFLAGS -DCPU=\\\"mipsel\\\""
+    supported_os="mipsel"
+    HOST_CPU=mipsel
+    ;;
+  mips*)
     CFLAGS="$CFLAGS -DCPU=\\\"mips\\\""
     supported_os="mips"
     HOST_CPU=mips
@@ -144,11 +149,6 @@ AC_DEFUN(AP_SUPPORTED_HOST,[
         HOST_CPU=PA_RISC2.0
     fi
     CFLAGS="$CFLAGS -DCPU=\\\"$HOST_CPU\\\" -DSO_EXT=\\\"sl\\\""
-    ;;
-  mipsel | mipsn32el | mips64el)
-    CFLAGS="$CFLAGS -DCPU=\\\"mipsel\\\""
-    supported_os="mipsel"
-    HOST_CPU=mipsel
     ;;
   ia64w)
     CFLAGS="$CFLAGS -DCPU=\\\"IA64W\\\" -DSO_EXT=\\\"so\\\""


### PR DESCRIPTION
For mips, we add some new CPU types: mipsisa64r6{,el}, mipsisa32r6{,el}.
To add support of them and don't make the list too long, 
we detect mips*el and then mips*.