### PR TITLE
[DAEMON-414] prunsrv uses its log is before it is initialized.

### DIFF
--- a/src/native/windows/apps/prunsrv/prunsrv.c
+++ b/src/native/windows/apps/prunsrv/prunsrv.c
@@ -1742,10 +1742,10 @@ void __cdecl main(int argc, char **argv)
     /* Create the main Pool */
     gPool = apxPoolCreate(NULL, 0);
 
-	apxLogOpen(gPool, SO_LOGPATH, SO_LOGPREFIX, SO_LOGROTATE);
-	apxLogLevelSetW(NULL, SO_LOGLEVEL);
-	apxLogWrite(APXLOG_MARK_DEBUG "Apache Commons Daemon procrun (%s %d-bit) logging initialized.",
-		        PRG_VERSION, PRG_BITS);
+    apxLogOpen(gPool, SO_LOGPATH, SO_LOGPREFIX, SO_LOGROTATE);
+    apxLogLevelSetW(NULL, SO_LOGLEVEL);
+    apxLogWrite(APXLOG_MARK_DEBUG "Apache Commons Daemon procrun (%s %d-bit) logging initialized.",
+                PRG_VERSION, PRG_BITS);
 
 	/* Parse the command line */
     if ((lpCmdline = apxCmdlineParse(gPool, _options, _commands, _altcmds)) == NULL) {

--- a/src/native/windows/apps/prunsrv/prunsrv.c
+++ b/src/native/windows/apps/prunsrv/prunsrv.c
@@ -1749,7 +1749,7 @@ void __cdecl main(int argc, char **argv)
     if (SO_LOGROTATE)
         apxLogWrite(APXLOG_MARK_DEBUG "Log will rotate each %d seconds.", SO_LOGROTATE);
 
-	/* Parse the command line */
+    /* Parse the command line */
     if ((lpCmdline = apxCmdlineParse(gPool, _options, _commands, _altcmds)) == NULL) {
         apxLogWrite(APXLOG_MARK_ERROR "Invalid command line arguments.");
         rv = 1;

--- a/src/native/windows/apps/prunsrv/prunsrv.c
+++ b/src/native/windows/apps/prunsrv/prunsrv.c
@@ -1742,7 +1742,12 @@ void __cdecl main(int argc, char **argv)
     /* Create the main Pool */
     gPool = apxPoolCreate(NULL, 0);
 
-    /* Parse the command line */
+	apxLogOpen(gPool, SO_LOGPATH, SO_LOGPREFIX, SO_LOGROTATE);
+	apxLogLevelSetW(NULL, SO_LOGLEVEL);
+	apxLogWrite(APXLOG_MARK_DEBUG "Apache Commons Daemon procrun (%s %d-bit) logging initialized.",
+		        PRG_VERSION, PRG_BITS);
+
+	/* Parse the command line */
     if ((lpCmdline = apxCmdlineParse(gPool, _options, _commands, _altcmds)) == NULL) {
         apxLogWrite(APXLOG_MARK_ERROR "Invalid command line arguments.");
         rv = 1;
@@ -1758,9 +1763,6 @@ void __cdecl main(int argc, char **argv)
         }
     }
 
-    apxLogOpen(gPool, SO_LOGPATH, SO_LOGPREFIX, SO_LOGROTATE);
-    apxLogLevelSetW(NULL, SO_LOGLEVEL);
-    apxLogWrite(APXLOG_MARK_DEBUG "Apache Commons Daemon procrun log initialized.");
     if (SO_LOGROTATE)
         apxLogWrite(APXLOG_MARK_DEBUG "Log will rotate each %d seconds.", SO_LOGROTATE);
 

--- a/src/native/windows/apps/prunsrv/prunsrv.c
+++ b/src/native/windows/apps/prunsrv/prunsrv.c
@@ -1746,6 +1746,8 @@ void __cdecl main(int argc, char **argv)
     apxLogLevelSetW(NULL, SO_LOGLEVEL);
     apxLogWrite(APXLOG_MARK_DEBUG "Apache Commons Daemon procrun (%s %d-bit) logging initialized.",
                 PRG_VERSION, PRG_BITS);
+    if (SO_LOGROTATE)
+        apxLogWrite(APXLOG_MARK_DEBUG "Log will rotate each %d seconds.", SO_LOGROTATE);
 
 	/* Parse the command line */
     if ((lpCmdline = apxCmdlineParse(gPool, _options, _commands, _altcmds)) == NULL) {
@@ -1762,9 +1764,6 @@ void __cdecl main(int argc, char **argv)
             goto cleanup;
         }
     }
-
-    if (SO_LOGROTATE)
-        apxLogWrite(APXLOG_MARK_DEBUG "Log will rotate each %d seconds.", SO_LOGROTATE);
 
     apxLogWrite(APXLOG_MARK_INFO "Apache Commons Daemon procrun (%s %d-bit) started.",
                 PRG_VERSION, PRG_BITS);


### PR DESCRIPTION
@markt-asf Please review.