### PR TITLE
psupport.m4: remove incorrect definition

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -53,6 +53,11 @@
       <action type="add" dev="markt">
         procrun. Add additional debug logging for Java start mode.
       </action>
+      <action type="fix" dev="markt" due-to="Ray Wang">
+        jsvc. Remove incorrent definition 'supported_os' which defined in 
+        psupport.m4 file to fix jsvc build error on s390, arm, aarch64, 
+        mipsel and mips. 
+      </action>
     </release>
     <release version="1.2.2" date="2019-10-04" description="Bug fix release">
       <action issue="DAEMON-408" type="fix" dev="markt">

--- a/src/native/unix/support/apsupport.m4
+++ b/src/native/unix/support/apsupport.m4
@@ -118,17 +118,14 @@ AC_DEFUN(AP_SUPPORTED_HOST,[
     ;;
   mips*el)
     CFLAGS="$CFLAGS -DCPU=\\\"mipsel\\\""
-    supported_os="mipsel"
     HOST_CPU=mipsel
     ;;
   mips*)
     CFLAGS="$CFLAGS -DCPU=\\\"mips\\\""
-    supported_os="mips"
     HOST_CPU=mips
     ;;
   alpha*)
     CFLAGS="$CFLAGS -DCPU=\\\"alpha\\\""
-    supported_os="alpha"
     HOST_CPU=alpha
     ;;
   hppa2.0w|hppa64)
@@ -174,17 +171,14 @@ AC_DEFUN(AP_SUPPORTED_HOST,[
     HOST_CPU=$host_cpu;;
   s390 | s390x)
     CFLAGS="$CFLAGS -DCPU=\\\"s390\\\""
-    supported_os="s390"
     HOST_CPU=s390
     ;;
   arm*)
     CFLAGS="$CFLAGS -DCPU=\\\"arm\\\""
-    supported_os="arm"
     HOST_CPU=arm
     ;;
   aarch64)
     CFLAGS="$CFLAGS -DCPU=\\\"aarch64\\\""
-    supported_os="aarch64"
     HOST_CPU=aarch64
     ;;
   *)


### PR DESCRIPTION
Fix jsvc build error on s390, arm, aarch64, mipsel, mips. jni_md.h file
could not be found, due to incorrent definition ‘supported_os’. it should
not be defined as the architecture of the cpu.

Because I don't know how to modify the previous commit，so i gave up the previous pull request, and resubmitted.- -|