### PR TITLE
DAEMON-336 - If lCallbacks is empty don't call the fnCallbacks to avoid an ACCESS_VIOLATION

### DIFF
--- a/src/native/windows/src/handles.c
+++ b/src/native/windows/src/handles.c
@@ -496,13 +496,15 @@ apxCloseHandle(APXHANDLE hObject)
 
     if (IS_INVALID_HANDLE(hObject) || hObject->dwType == APXHANDLE_TYPE_INVALID)
         return FALSE;
-    /* Call the user callback first */
-    (*hObject->fnCallback)(hObject, WM_CLOSE, 0, 0);
-    /* Now go through the callback chain */
-    TAILQ_FOREACH(lpCall, &hObject->lCallbacks, queue) {
+    if (!TAILQ_EMPTY(&hObject->lCallbacks)) {
+        /* Call the user callback first */
+        (*hObject->fnCallback)(hObject, WM_CLOSE, 0, 0);
+        /* Now go through the callback chain */
+        TAILQ_FOREACH(lpCall, &hObject->lCallbacks, queue) {
         (*lpCall->fnCallback)(hObject, WM_CLOSE, 0, 0);
-        TAILQ_REMOVE(&hObject->lCallbacks, lpCall, queue);
-        __apxPoolFreeCore(lpCall);
+            TAILQ_REMOVE(&hObject->lCallbacks, lpCall, queue);
+            __apxPoolFreeCore(lpCall);
+        }
     }
 
     hObject->dwType = APXHANDLE_TYPE_INVALID;


### PR DESCRIPTION
This is a more specific patch instead of removing the `apxHandleManagerDestroy();` as suggested as a workaround. It seems that if there are no callbacks, this is empty and can throw an ACCESS VIOLATION. Instead ignore the callbacks if lCallbacks is empty.