### PR TITLE
Fix for https://issues.redhat.com/browse/JBCS-1261

### DIFF
--- a/src/native/windows/apps/prunsrv/prunsrv.c
+++ b/src/native/windows/apps/prunsrv/prunsrv.c
@@ -1538,6 +1538,7 @@ void WINAPI service_ctrl_handler(DWORD dwCtrlCode)
         case SERVICE_CONTROL_SHUTDOWN:
             apxLogWrite(APXLOG_MARK_INFO "Service SHUTDOWN signalled.");
         case SERVICE_CONTROL_STOP:
+            apxLogWrite(APXLOG_MARK_INFO "Service SERVICE_CONTROL_STOP signalled.");
             if (SO_STOPTIMEOUT > 0) {
                 reportServiceStatus(SERVICE_STOP_PENDING, NO_ERROR, SO_STOPTIMEOUT * 1000);
             }
@@ -1552,6 +1553,7 @@ void WINAPI service_ctrl_handler(DWORD dwCtrlCode)
             CloseHandle(stopThread);
             return;
         case SERVICE_CONTROL_INTERROGATE:
+            apxLogWrite(APXLOG_MARK_INFO "Service SERVICE_CONTROL_INTERROGATE signalled.");
             reportServiceStatusE(APXLOG_LEVEL_TRACE,
                                 _service_status.dwCurrentState,
                                 _service_status.dwWin32ExitCode,

--- a/src/native/windows/src/rprocess.c
+++ b/src/native/windows/src/rprocess.c
@@ -792,14 +792,14 @@ apxProcessWait(APXHANDLE hProcess, DWORD dwMilliseconds, BOOL bKill)
     if (hProcess->dwType != APXHANDLE_TYPE_PROCESS)
         return WAIT_ABANDONED;
 
-    apxLogWrite(APXLOG_MARK_DEBUG "apxProcessWait..");
+    apxLogWrite(APXLOG_MARK_DEBUG "apxProcessWait.");
     lpProc = APXHANDLE_DATA(hProcess);
 
     if (lpProc->dwChildStatus & CHILD_RUNNING) {
         DWORD rv = WaitForMultipleObjects(3, lpProc->hWorkerThreads,
                                           TRUE, dwMilliseconds);
         if (rv == WAIT_TIMEOUT && bKill) {
-            apxLogWrite(APXLOG_MARK_DEBUG "apxProcessWait.. killing???");
+            apxLogWrite(APXLOG_MARK_DEBUG "apxProcessWait. killing???");
             __apxProcessCallback(hProcess, WM_CLOSE, 0, 0);
         }
         return rv;

--- a/src/native/windows/src/rprocess.c
+++ b/src/native/windows/src/rprocess.c
@@ -373,6 +373,7 @@ static BOOL __apxProcessClose(APXHANDLE hProcess)
     lpProc = APXHANDLE_DATA(hProcess);
     CHECK_IF_ACTIVE(lpProc);
 
+    /* dry run to get debug information */
     __apxProcessTerminateChild(lpProc->stProcInfo.dwProcessId, TRUE);
     /* Try to close the child's stdin first */
     SAFE_CLOSE_HANDLE(lpProc->hChildInpWr);
@@ -409,7 +410,9 @@ static BOOL __apxProcessClose(APXHANDLE hProcess)
                 if (!GetExitCodeProcess(lpProc->stProcInfo.hProcess, &status) ||
                                 (status != STILL_ACTIVE)) {
                      apxLogWrite(APXLOG_MARK_DEBUG "__apxProcessClose Gone(thread exit)");
-                     // We are here when the service starts something like wildfly via standalone.sh and wildfly doesn't terminate cleanly, 
+                     /* We are here when the service starts something like wildfly via standalone.sh and wildfly doesn't terminate cleanly, 
+                      * dry run is FALSE: we kill all the process of the process tree
+                      */
                      __apxProcessTerminateChild(lpProc->stProcInfo.dwProcessId, FALSE);
                 }
 


### PR DESCRIPTION
Terminate child process that have been started by the service.
That fixes problem what using wildfly standalone.bat that creates java.exe, if the stop cli fails stopping the bat doesn't stop the java.exe...