### PR TITLE
Fix incorrect definition in riscv64 architecture

### DIFF
--- a/src/native/unix/support/apsupport.m4
+++ b/src/native/unix/support/apsupport.m4
@@ -183,7 +183,6 @@ AC_DEFUN(AP_SUPPORTED_HOST,[
     ;;
   riscv64)
     CFLAGS="$CFLAGS -DCPU=\\\"riscv64\\\""
-    supported_os="riscv64"
     HOST_CPU=riscv64
     ;;
   *)


### PR DESCRIPTION
fix jsvc build error on riscv64.  jni_md.h file could not be found.

build log:
```
make[1]: Entering directory '/build/java-commons-daemon/src/commons-daemon/src/native/unix/native'
gcc -march=rv64gc -mabi=lp64d -O2 -pipe -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -flto=auto -DOS_LINUX -DDSO_DLFCN -DCPU=\"riscv64\" -Wall -Wstrict-prototypes   -I/usr/lib/jvm/default/include -I/usr/lib/jvm/default/include/riscv64 -c jsvc-unix.c -o jsvc-unix.o
gcc -march=rv64gc -mabi=lp64d -O2 -pipe -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -flto=auto -DOS_LINUX -DDSO_DLFCN -DCPU=\"riscv64\" -Wall -Wstrict-prototypes   -I/usr/lib/jvm/default/include -I/usr/lib/jvm/default/include/riscv64 -c arguments.c -o arguments.o
gcc -march=rv64gc -mabi=lp64d -O2 -pipe -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -flto=auto -DOS_LINUX -DDSO_DLFCN -DCPU=\"riscv64\" -Wall -Wstrict-prototypes   -I/usr/lib/jvm/default/include -I/usr/lib/jvm/default/include/riscv64 -c debug.c -o debug.o
gcc -march=rv64gc -mabi=lp64d -O2 -pipe -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -flto=auto -DOS_LINUX -DDSO_DLFCN -DCPU=\"riscv64\" -Wall -Wstrict-prototypes   -I/usr/lib/jvm/default/include -I/usr/lib/jvm/default/include/riscv64 -c dso-dlfcn.c -o dso-dlfcn.o
gcc -march=rv64gc -mabi=lp64d -O2 -pipe -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -flto=auto -DOS_LINUX -DDSO_DLFCN -DCPU=\"riscv64\" -Wall -Wstrict-prototypes   -I/usr/lib/jvm/default/include -I/usr/lib/jvm/default/include/riscv64 -c dso-dyld.c -o dso-dyld.o
gcc -march=rv64gc -mabi=lp64d -O2 -pipe -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -flto=auto -DOS_LINUX -DDSO_DLFCN -DCPU=\"riscv64\" -Wall -Wstrict-prototypes   -I/usr/lib/jvm/default/include -I/usr/lib/jvm/default/include/riscv64 -c help.c -o help.o
gcc -march=rv64gc -mabi=lp64d -O2 -pipe -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -flto=auto -DOS_LINUX -DDSO_DLFCN -DCPU=\"riscv64\" -Wall -Wstrict-prototypes   -I/usr/lib/jvm/default/include -I/usr/lib/jvm/default/include/riscv64 -c home.c -o home.o
gcc -march=rv64gc -mabi=lp64d -O2 -pipe -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -flto=auto -DOS_LINUX -DDSO_DLFCN -DCPU=\"riscv64\" -Wall -Wstrict-prototypes   -I/usr/lib/jvm/default/include -I/usr/lib/jvm/default/include/riscv64 -c java.c -o java.o
gcc -march=rv64gc -mabi=lp64d -O2 -pipe -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -flto=auto -DOS_LINUX -DDSO_DLFCN -DCPU=\"riscv64\" -Wall -Wstrict-prototypes   -I/usr/lib/jvm/default/include -I/usr/lib/jvm/default/include/riscv64 -c location.c -o location.o
gcc -march=rv64gc -mabi=lp64d -O2 -pipe -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -flto=auto -DOS_LINUX -DDSO_DLFCN -DCPU=\"riscv64\" -Wall -Wstrict-prototypes   -I/usr/lib/jvm/default/include -I/usr/lib/jvm/default/include/riscv64 -c replace.c -o replace.o
gcc -march=rv64gc -mabi=lp64d -O2 -pipe -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -flto=auto -DOS_LINUX -DDSO_DLFCN -DCPU=\"riscv64\" -Wall -Wstrict-prototypes   -I/usr/lib/jvm/default/include -I/usr/lib/jvm/default/include/riscv64 -c locks.c -o locks.o
gcc -march=rv64gc -mabi=lp64d -O2 -pipe -fexceptions         -Wp,-D_FORTIFY_SOURCE=2 -Wformat -Werror=format-security         -fstack-clash-protection -flto=auto -DOS_LINUX -DDSO_DLFCN -DCPU=\"riscv64\" -Wall -Wstrict-prototypes   -I/usr/lib/jvm/default/include -I/usr/lib/jvm/default/include/riscv64 -c signals.c -o signals.o
In file included from java.c:23:
/usr/lib/jvm/default/include/jni.h:45:10: fatal error: jni_md.h: No such file or directory
   45 | #include "jni_md.h"
      |          ^~~~~~~~~~
compilation terminated.
make[1]: *** [../Makedefs:31: java.o] Error 1
```

This PR is the same as https://github.com/apache/commons-daemon/pull/16