### PR TITLE
Remove reference to IRC channel (no longer exists)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,5 @@ Additional Resources
 + [Apache Commons Homepage](https://commons.apache.org/)
 + [Apache Issue Tracker (JIRA)](https://issues.apache.org/jira/browse/DAEMON)
 + [Apache Commons Twitter Account](https://twitter.com/ApacheCommons)
-+ `#apache-commons` IRC channel on `irc.freenode.org`
 
 [ml]:https://commons.apache.org/mail-lists.html


### PR DESCRIPTION
If Apache Commons has an IRC presence somewhere, please disregard this PR and update the reference instead.  I confirmed that the current reference leads to an empty IRC channel.