### PR TITLE
Fix signal handling setup.

### DIFF
--- a/src/native/unix/native/jsvc-unix.c
+++ b/src/native/unix/native/jsvc-unix.c
@@ -901,7 +901,7 @@ static int child(arg_data *args, home_data *data, uid_t uid, gid_t gid)
 
     /* Install signal handlers */
     memset(&act, '\0', sizeof(act));
-    act.sa_handler = handler;
+    act.sa_sigaction = handler;
     sigemptyset(&act.sa_mask);
     act.sa_flags = SA_RESTART | SA_NOCLDSTOP;
 


### PR DESCRIPTION
The signal handler was being assigned to the sa_handler member of the sigaction struct, which is incorrect; it should be assigned to the sa_sigaction member.  The sa_handler is only for using the default handler or ignoring the signal.  This worked only because the two fields are genrally a union, but new enough compilers will flag this as an error.