### PR TITLE
Fix first appearance of --enable-native-access

### DIFF
--- a/src/changes/changes.xml
+++ b/src/changes/changes.xml
@@ -44,6 +44,7 @@
       <!-- FIX -->
       <action type="fix" dev="ggregory" due-to="Gary Gregory">Remove -nouses directive from maven-bundle-plugin. OSGi package imports now state 'uses' definitions for package imports, this doesn't affect JPMS (from org.apache.commons:commons-parent:80).</action>
       <action type="fix" dev="michaelo">Document --enable-preview</action>
+      <action type="fix" dev="michaelo">Fix first appearance of --enable-native-access</action>
       <!-- ADD -->
       <action issue="DAEMON-471" dev="michaelo" type="add">Add support for --enable-native-access Java startup option in jsvc.</action>
       <!-- UPDATE -->

--- a/src/native/unix/native/arguments.c
+++ b/src/native/unix/native/arguments.c
@@ -426,7 +426,7 @@ static arg_data *parse(int argc, char *argv[])
         else if (!strncmp(argv[x], "--enable-preview", 16)) {
             args->opts[args->onum++] = strdup(argv[x]);
         }
-        /* Java 21 specific options */
+        /* Java 17 specific options */
         else if (!strncmp(argv[x], "--enable-native-access=", 23)) {
             args->opts[args->onum++] = strdup(argv[x]);
         }

--- a/src/native/unix/native/help.c
+++ b/src/native/unix/native/help.c
@@ -124,7 +124,7 @@ void help(home_data *data)
     printf("    --enable-preview\n");
     printf("        Java 11 --enable-preview option. Passed as it is to JVM\n");
     printf("    --enable-native-access=<module name>\n");
-    printf("        Java 21 --enable-native-access option. Passed as it is to JVM\n");
+    printf("        Java 17 --enable-native-access option. Passed as it is to JVM\n");
     printf("\njsvc (Apache Commons Daemon) " JSVC_VERSION_STRING "\n");
     printf("Copyright (c) 1999-2025 Apache Software Foundation.\n");
 


### PR DESCRIPTION
As it turns out '--enable-native-access' is not reported by 'java -help', but appeared first in Java 17:
https://github.com/openjdk/jdk17u/blob/af0de21b9bac2b593e2b50703e2995cd7a9cfb42/src/java.base/share/native/libjli/java.c#L600

<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [ ] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [ ] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible but is a best-practice.
- [ ] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [ ] Each commit in the pull request should have a meaningful subject line and body. Note that commits might be squashed by a maintainer on merge.
