### PR TITLE
Fix for DAEMON-398 and corresponding tests.

### DIFF
--- a/src/native/windows/apps/prunsrv/test/scripts/cleanstd.bat
+++ b/src/native/windows/apps/prunsrv/test/scripts/cleanstd.bat
@@ -14,26 +14,16 @@ rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 rem See the License for the specific language governing permissions and
 rem limitations under the License.
 
-SET result=0
-SETLOCAL ENABLEDELAYEDEXPANSION
-for /l %%x in (1, 1, 100) do (
-  echo "testing service %%x"
-  java -cp %myjar% org.apache.commons.daemon.ProcrunDaemon 1 > nul 2>&1
-  findstr Exception client.txt > nul 2>&1
-  IF !ERRORLEVEL! EQU 0 (
-    echo "Found"
-    SET result=1
-    goto :EndLoop
-  ) ELSE (
-    echo "NOT Found"
-  )
-  timeout /t 10 > nul
-)
+rem the files:
+rem rw-r--r-- 1 Administrator None      0 Apr 28 00:55 testservice-stderr.2025-04-28.log
+rem rw-r--r-- 1 Administrator None      0 Apr 28 00:55 testservice-stdout.2025-04-28.log
+rem needs to be removed between tests.
 
-:EndLoop
-ENDLOCAL
-echo "Done result: %result%"
-IF %result% EQU 0 (
-  exit /b 0
-)
-exit /b 1
+SET "full_date=%date:~4,10%"
+SET "month=%full_date:~0,2%"
+SET "day=%full_date:~3,2%"
+SET "year=%full_date:~6,4%"
+
+del "testservice-stdout.%year%-%month%-%day%.log" 2>nul
+
+del "testservice-stderr.%year%-%month%-%day%.log" 2>nul

--- a/src/native/windows/apps/prunsrv/test/scripts/isemptystd.bat
+++ b/src/native/windows/apps/prunsrv/test/scripts/isemptystd.bat
@@ -1,0 +1,51 @@
+@ECHO OFF
+rem Licensed to the Apache Software Foundation (ASF) under one or more
+rem contributor license agreements.  See the NOTICE file distributed with
+rem this work for additional information regarding copyright ownership.
+rem The ASF licenses this file to You under the Apache License, Version 2.0
+rem (the "License"); you may not use this file except in compliance with
+rem the License.  You may obtain a copy of the License at
+rem
+rem     http://www.apache.org/licenses/LICENSE-2.0
+rem
+rem Unless required by applicable law or agreed to in writing, software
+rem distributed under the License is distributed on an "AS IS" BASIS,
+rem WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+rem See the License for the specific language governing permissions and
+rem limitations under the License.
+
+rem the files:
+rem rw-r--r-- 1 Administrator None      0 Apr 28 00:55 testservice-stderr.2025-04-28.log
+rem rw-r--r-- 1 Administrator None      0 Apr 28 00:55 testservice-stdout.2025-04-28.log
+rem should NOT be empty
+
+SET "full_date=%date:~4,10%"
+SET "month=%full_date:~0,2%"
+SET "day=%full_date:~3,2%"
+SET "year=%full_date:~6,4%"
+CALL :TestFile "testservice-stdout.%year%-%month%-%day%.log"
+IF %ERRORLEVEL% EQU 1 (
+  echo "FAILED: stdout file empty or not existing"
+  exit 1
+)
+CALL :TestFile "testservice-stderr.%year%-%month%-%day%.log"
+IF %ERRORLEVEL% EQU 1 (
+  echo "FAILED stderr file empty or not existing"
+  exit 1
+)
+
+goto :eof
+
+:TestFile
+SET "filepath=%~1" 
+IF NOT EXIST "%filepath%" (
+  echo "file %filepath% don't exist"
+  exit /b 1
+)
+echo %~z1
+If %~z1 EQU 0 (
+  echo "file %filepath% is empty"
+  Exit /B 1
+)
+echo "file %filepath% is NOT empty"
+Exit /B 0

--- a/src/test/java/org/apache/commons/daemon/ProcrunDaemon.java
+++ b/src/test/java/org/apache/commons/daemon/ProcrunDaemon.java
@@ -77,6 +77,19 @@ class ProcrunDaemon {
                         System.out.println(ex);
                     }
                     System.exit(0);
+                } else if (buf[0] == '5') {
+                    System.out.println("5");
+                    /* Note that System.out has been redirected to client.txt in main() */
+                    PrintStream myout = System.out;
+                    System.setOut(originalStdout);
+                    System.out.println("Using System.out");
+                    System.out.println("5");
+                    System.out.println("Back to redirection");
+                    System.setOut(myout);
+                } else if (buf[0] == '6') {
+                    System.out.println("6");
+                    System.err.println("Using System.err");
+                    System.err.println("6");
                 }
             }
             System.out.println("num " + num);
@@ -129,8 +142,11 @@ class ProcrunDaemon {
         System.exit(0);
     }
 
+    static PrintStream originalStdout;
+
     /* client server test for procrun */
     public static void main(String[] argv) {
+        originalStdout = System.out;
         if (argv.length != 0) {
             /* Just send the command to the server */
             try {


### PR DESCRIPTION

Arrange the logic around stderr/stdout when a console is created, use the advised method to redirect stderr/stdout instead just assigning stderr/stdout to the file.
Add the corresponding tests and improve some bat functions.