### PR TITLE
Add support for windows arm64 architecture for prunsrv.exe

### DIFF
--- a/src/native/windows/README.txt
+++ b/src/native/windows/README.txt
@@ -29,6 +29,16 @@ Windows X86 Build
   
   nmake CPU=X86
 
+Windows ARM64 Build
+
+  For MVS under "C:\Program Files (x86)":
+  "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsarm64.bat"
+
+  For MVS under "C:\Program Files":
+  "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsarm64.bat"
+
+  nmake CPU=ARM64
+
 
 Additional configuration
 ========================

--- a/src/native/windows/include/Makefile.inc
+++ b/src/native/windows/include/Makefile.inc
@@ -103,6 +103,9 @@ CPU=X86
 !IF "$(BUILD_CPU)" == "AMD64" || "$(BUILD_CPU)" == "amd64" || "$(BUILD_CPU)" == "x86_64" || "$(BUILD_CPU)" == "x64"
 CPU=X64
 !ENDIF
+!IF "$(BUILD_CPU)" == "ARM64" || "$(BUILD_CPU)" == "arm64"
+CPU=ARM64
+!ENDIF
 # did we manage to set CPU?
 !IF !DEFINED(CPU) || "$(CPU)" == ""
 !ERROR Unexpected value of BUILD_CPU: $(BUILD_CPU) or PROCESSOR_ARCHITECTURE=$(PROCESSOR_ARCHITECTURE) or PROCESSOR_ARCHITEW6432=$(PROCESSOR_ARCHITEW6432).
@@ -111,7 +114,9 @@ CPU=X64
 
 !IF "$(CPU)" != "X86"
 !IF "$(CPU)" != "X64"
-!ERROR Must specify CPU environment variable (X86, X64) $(CPU)
+!IF "$(CPU)" != "ARM64"
+!ERROR Must specify CPU environment variable (X86, X64, ARM64) $(CPU)
+!ENDIF
 !ENDIF
 !ENDIF
 
@@ -173,6 +178,10 @@ MACHINE_LC=i386
 CPU_CFLAGS = -D_AMD64_=1 -DWIN64 -D_WIN64
 MACHINE=AMD64
 MACHINE_LC=amd64
+!ELSEIF "$(CPU)" == "ARM64"
+CPU_CFLAGS = -D_ARM64_=1 -DWIN64 -D_WIN64
+MACHINE=ARM64
+MACHINE_LC=arm64
 !ENDIF
 
 !IF "$(BUILD)" == "RELEASE"
@@ -290,7 +299,7 @@ JAVA_INCLUDES=-I "$(JAVA_HOME)\include" -I "$(JAVA_HOME)\include\win32"
 !IF "$(CPU)" == "X86"
 ML = ml.exe
 AFLAGS = /coff /Zi /c
-!ELSEIF "$(CPU)" == "X64"
+!ELSEIF "$(CPU)" == "X64" || "$(CPU)" == "ARM64"
 ML = ml64.exe
 AFLAGS = /Zi /c
 !ENDIF


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    https://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

This adds ARM64 support for Windows binaries as discussed in https://issues.apache.org/jira/browse/DAEMON-462

Based on this PR I kindly request to include an ARM64 binary of `prunsrv.exe` in future `commons-daemon` releases.