### PR TITLE
Update windows workflow for use with VisualStudio 2026

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -65,7 +65,7 @@ jobs:
         shell: cmd
         run: |
             echo on
-            call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=${{ matrix.arch }}
+            call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=${{ matrix.arch }}
             cd src/native/windows/apps/prunsrv
             echo "Building prunsrv for ${{ matrix.arch }}"
             nmake BUILD_CPU=${{ matrix.arch }}
@@ -73,7 +73,7 @@ jobs:
         shell: cmd
         run: |
             echo on
-            call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=${{ matrix.arch }}
+            call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=${{ matrix.arch }}
             cd src/native/windows/apps/prunmgr
             echo "Building prunmgr for ${{ matrix.arch }}"
             nmake BUILD_CPU=${{ matrix.arch }}


### PR DESCRIPTION
I noticed the recent [CI failures](https://github.com/apache/commons-daemon/actions/workflows/windows.yml). These are caused by a rollout of a [new runner image](https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-VS2026-Readme.md) that now uses a newer Visual Studio. This PR updates the path for the new VS.