### PR TITLE
Generate ARM `prunsrv.exe` in CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -78,7 +78,9 @@ jobs:
         shell: cmd
         run: |
             echo on
-            call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=${{ matrix.arch }}
+            where /R "C:\Program Files\Microsoft Visual Studio" VsDevCmd.bat > vs_setup_path
+            set /p SETUP_VS=< vs_setup_path
+            call "%SETUP_VS%" -arch=${{ matrix.arch }}
             cd src/native/windows/apps/prunsrv
             echo "Building prunsrv for ${{ matrix.arch }}"
             nmake BUILD_CPU=${{ matrix.arch }}
@@ -86,7 +88,9 @@ jobs:
         shell: cmd
         run: |
             echo on
-            call "C:\Program Files\Microsoft Visual Studio\18\Enterprise\Common7\Tools\VsDevCmd.bat" -arch=${{ matrix.arch }}
+            set /p SETUP_VS=< vs_setup_path
+            call "%SETUP_VS%" -arch=${{ matrix.arch }}
+            del vs_setup_path
             cd src/native/windows/apps/prunmgr
             echo "Building prunmgr for ${{ matrix.arch }}"
             nmake BUILD_CPU=${{ matrix.arch }}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -43,12 +43,22 @@ jobs:
       matrix:
         include:
           - name: Default
+            image: windows-latest
             triplet: x64-windows
             arch: x64
+            java-arch: X64
             build-type: Debug
             generator: "Ninja"
 
-    runs-on: windows-latest
+          - name: Default on ARM
+            image: windows-11-arm
+            triplet: arm64-windows
+            arch: arm64
+            java-arch: AARCH64
+            build-type: Debug
+            generator: "Ninja"
+
+    runs-on: ${{ matrix.image }}
     timeout-minutes: 30
     name: ${{ matrix.name }}
     env: 
@@ -61,7 +71,7 @@ jobs:
         shell: cmd
         run: |
             echo rem SPDX-License-Identifier: Apache-2.0> set_java_home.bat
-            echo set JAVA_HOME=%JAVA_HOME_21_X64%>> set_java_home.bat
+            echo set JAVA_HOME=%JAVA_HOME_21_${{ matrix.java-arch }}%>> set_java_home.bat
             call .\set_java_home.bat
             echo "JAVA_HOME: %JAVA_HOME%"
       - name: Build prunsrv
@@ -95,5 +105,5 @@ jobs:
             test.bat
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: windows-artifact
+          name: windows-artifact-${{ matrix.arch }}
           path: src/native/windows/apps/prunsrv/*/prunsrv.exe


### PR DESCRIPTION
A follow-up on #311 that builds prunsrv.exe on the Windows ARM runner. It now runs the Windows job twice, generating two different artifacts with the architecture in the zip name.

I'm not very fluent in Windows cmd, so maybe it can be written in a cleaner way, but I don't know how.